### PR TITLE
Fix expire_empty_row_count

### DIFF
--- a/subscriptions/views.py
+++ b/subscriptions/views.py
@@ -70,9 +70,9 @@ class MainListView(TemplateView):
             expire = expire[:5]
         else:
             expire_empty_row_count = 5 - expire.count()
+            context['expire_empty_row_count'] = expire_empty_row_count
 
         context['expire_qs'] = expire
-        context['expire_empty_row_count'] = expire_empty_row_count
 
         return context
 


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
-[ ] 기능 추가
-[ ] 기능 삭제
-[v] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
bugfix/view -> develop

### 변경 사항
main 페이지의 구독중인 서비스 테이블에서 데이터가 5개 미만일 때, 빈 데이터 생성 시 발생하던 오류 수정

### 테스트 결과
정상 작동 확인
